### PR TITLE
Set ctrlp colors to normal tender colors. Should fix #25

### DIFF
--- a/autoload/airline/themes/tender.vim
+++ b/autoload/airline/themes/tender.vim
@@ -37,9 +37,9 @@ let g:airline#themes#tender#palette.inactive = airline#themes#generate_color_map
 if !get(g:, 'loaded_ctrlp', 0)
   finish
 endif
-let s:CP1 = [ "", "", ,  ]
-let s:CP2 = [ "", "", ,  ]
-let s:CP3 = [ "", "", ,  ]
+let s:CP1 = [ "#335261", "#b3deef", 239, 153, '' ]
+let s:CP2 = [ "#282828", "#73cef4", 235, 81, '' ]
+let s:CP3 = [ "#b3deef", "#444444", 153, 238, 'bold' ]
 
 let g:airline#themes#tender#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(s:CP1, s:CP2, s:CP3)
 

--- a/autoload/airline/themes/tenderplus.vim
+++ b/autoload/airline/themes/tenderplus.vim
@@ -37,9 +37,9 @@ let g:airline#themes#tenderplus#palette.inactive = airline#themes#generate_color
 if !get(g:, 'loaded_ctrlp', 0)
   finish
 endif
-let s:CP1 = [ "", "", ,  ]
-let s:CP2 = [ "", "", ,  ]
-let s:CP3 = [ "", "", ,  ]
+let s:CP1 = [ "#b3deef", "#335261", 153, 239, '' ]
+let s:CP2 = [ "#282828", "#73cef4", 235, 81, '' ]
+let s:CP3 = [ "#44778d", "#b3deef", 66, 153, 'bold' ]
 
 let g:airline#themes#tenderplus#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(s:CP1, s:CP2, s:CP3)
 


### PR DESCRIPTION
This should fix the issue with the theme not autoloading with vim-airline. The colors may not be what you want, I just put the 'normal' mode colors for ctrlp.