### PR TITLE
adding suport por SignColumn, where neomake show errors and warnings

### DIFF
--- a/colors/tender.vim
+++ b/colors/tender.vim
@@ -201,6 +201,7 @@ hi javascriptFuncName guifg=#c9d05c ctermfg=185 guibg=NONE ctermbg=NONE gui=NONE
 hi yamlFlowString guifg=#d3b987 ctermfg=180 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi yamlFlowStringDelimiter guifg=#eeeeee ctermfg=255 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi yamlKeyValueDelimiter guifg=#f43753 ctermfg=203 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi SignColumn guifg=#282828 ctermfg=235 guibg=#282828 ctermbg=235 gui=NONE cterm=NONE
 
 let g:terminal_color_foreground = "#282828"
 let g:terminal_color_background = "#eeeeee"

--- a/colors/tender.vim
+++ b/colors/tender.vim
@@ -202,6 +202,7 @@ hi yamlFlowString guifg=#d3b987 ctermfg=180 guibg=NONE ctermbg=NONE gui=NONE cte
 hi yamlFlowStringDelimiter guifg=#eeeeee ctermfg=255 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi yamlKeyValueDelimiter guifg=#f43753 ctermfg=203 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi SignColumn guifg=#282828 ctermfg=235 guibg=#282828 ctermbg=235 gui=NONE cterm=NONE
+hi VertSplit guifg=#808080 guibg=#282828
 
 let g:terminal_color_foreground = "#282828"
 let g:terminal_color_background = "#eeeeee"


### PR DESCRIPTION
There was no support for SignColumn so I added a line that leaves it the same color as the backgroud.
This is interesting because this is where neomake and syntastic shows the icons of errors and warnings.