### PR TITLE
Set the colors for conceal character

### DIFF
--- a/colors/tender.vim
+++ b/colors/tender.vim
@@ -27,6 +27,7 @@ hi ErrorMsg guifg=#f43753 ctermfg=203 guibg=NONE ctermbg=NONE gui=reverse cterm=
 hi VertSplit guifg=#282828 ctermfg=235 guibg=#282828 ctermbg=235 gui=NONE cterm=NONE
 hi Folded guifg=#666666 ctermfg=242 guibg=#1d1d1d ctermbg=234 gui=NONE cterm=NONE
 hi FoldColumn guifg=#666666 ctermfg=242 guibg=#1d1d1d ctermbg=234 gui=NONE cterm=NONE
+hi Conceal guifg=#504040 ctermfg=138 guibg=#504040 ctermbg=138 gui=NONE cterm=NONE
 hi IncSearch guifg=#282828 ctermfg=235 guibg=#ffffff ctermbg=15 gui=NONE cterm=NONE
 hi LineNr guifg=#444444 ctermfg=238 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi MatchParen guifg=#f43753 ctermfg=203 guibg=NONE ctermbg=NONE gui=bold cterm=bold


### PR DESCRIPTION
For use when concealment feature is enabled.
For example with https://github.com/plasticboy/vim-markdown

See the example with LaTeX file:
![image](https://user-images.githubusercontent.com/203261/59040538-724cd800-88a9-11e9-9562-b857deac1697.png)

