### PR TITLE
mod: link to Tender Kitty theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Copy color to vim if no exist `~/.vim/colors/`, create folder.
 - [Tender xresources](https://github.com/pebeto/tender-xresources) by [@pebeto](https://github.com/pebeto)
 - [Tender Blink Shell](https://github.com/Rafaelcv7/Jacoborus-Tendertheme) by [@Rafaelcv7](https://github.com/Rafaelcv7)
 - [Tender WezTerm](https://github.com/kyoheiu/tender-wezterm) by [@kyoheiu](https://github.com/kyoheiu)
+- [Tender Kitty](https://github.com/CompEng0001/tender-kitty) by [@CompEng0001](https://github.com/CompEng0001)
 
 <br><br>
 


### PR DESCRIPTION
I have made the [tender-kitty](https://github.com/CompEng0001/tender-kitty) theme for Kitty terminal  -> and added the link to the bottom of the README.md in the current format.

![2024-09-06_12-09-1725621521](https://github.com/user-attachments/assets/d8868e29-86a3-4cde-8962-d5d054f693f7)
