### PR TITLE
mod: link to Tender mintty theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Copy color to vim if no exist `~/.vim/colors/`, create folder.
 - [Tender xresources](https://github.com/pebeto/tender-xresources) by [@pebeto](https://github.com/pebeto)
 - [Tender Blink Shell](https://github.com/Rafaelcv7/Jacoborus-Tendertheme) by [@Rafaelcv7](https://github.com/Rafaelcv7)
 - [Tender WezTerm](https://github.com/kyoheiu/tender-wezterm) by [@kyoheiu](https://github.com/kyoheiu)
-- [Tender Kitty](https://github.com/CompEng0001/tender-kitty) by [@CompEng0001](https://github.com/CompEng0001)
+- [Tender Kitty](https://github.com/CompEng0001/tender-kitty) & [Tender Mintty](https://github.com/CompEng0001/tender-mintty) by [@CompEng0001](https://github.com/CompEng0001)
 
 <br><br>
 


### PR DESCRIPTION
I have another theme this time for mintty terminal,  [tender-mintty](https://github.com/CompEng0001/tender-mintty) ...

![image](https://github.com/user-attachments/assets/28712d35-5656-4755-80b7-83f3618f463c)

... and added the link to the bottom of the README.md in the current format.

![image](https://github.com/user-attachments/assets/c283ca14-de56-4550-bd3d-446f7dd51445)
